### PR TITLE
fix(blog-menu): remove unused blog option from menu dropdown, bump v1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bjornmelin-platform-io",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -98,13 +98,6 @@ export function Navbar() {
                 Projects
               </Link>
               <Link
-                href="/blog"
-                className="text-foreground/60 hover:text-foreground"
-                onClick={() => setIsMenuOpen(false)}
-              >
-                Blog
-              </Link>
-              <Link
                 href="/contact"
                 className="text-foreground/60 hover:text-foreground"
                 onClick={() => setIsMenuOpen(false)}


### PR DESCRIPTION
This pull request includes a version update and a simplification of the `Navbar` component by removing an unused link.

Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `1.0.0` to `1.0.1`.

Codebase simplification:

* [`src/components/layout/navbar.tsx`](diffhunk://#diff-8bbfe67f26475f1ecdbc080c9a1b3bb008d08b6e9451c911dc9b77407dc8a754L100-L106): Removed the `Blog` link from the `Navbar` component.