### PR TITLE
feat(metadata): Enhance Open Graph and Twitter metadata for improved SEO and sharing on home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,29 @@
 import { Hero } from "@/components/sections/hero";
 import { About } from "@/components/sections/about";
 import { FeaturedProjects } from "@/components/sections/featured-projects";
+import type { Metadata } from "next";
 
-export const metadata = {
+export const metadata: Metadata = {
   title: "Bjorn Melin - Senior Data Scientist & Cloud Solutions Architect",
   description:
     "Portfolio of Bjorn Melin, a Senior Data Scientist and Cloud Solutions Architect specializing in AI/ML solutions, GenAI innovation, and cloud-native architectures. 6x AWS Certified professional with expertise in machine learning and scalable cloud solutions.",
+  openGraph: {
+    type: 'website',
+    title: 'Bjorn Melin - Senior Data Scientist & Cloud Solutions Architect',
+    description: 'Portfolio of Bjorn Melin, a Senior Data Scientist and Cloud Solutions Architect specializing in AI/ML solutions, GenAI innovation, and cloud-native architectures.',
+    images: [{
+      url: '/screenshots/hero-preview.png',
+      width: 1200,
+      height: 630,
+      alt: 'Bjorn Melin - Portfolio Hero Section'
+    }]
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Bjorn Melin - Senior Data Scientist & Cloud Solutions Architect',
+    description: 'Portfolio of Bjorn Melin, a Senior Data Scientist and Cloud Solutions Architect specializing in AI/ML solutions, GenAI innovation, and cloud-native architectures.',
+    images: ['/screenshots/hero-preview.png']
+  }
 };
 
 export default function Home() {


### PR DESCRIPTION
This pull request includes an update to the `src/app/page.tsx` file to enhance the metadata for better SEO and social media integration. The most important changes include specifying the metadata type and adding Open Graph and Twitter card metadata.

Metadata enhancements:

* [`src/app/page.tsx`](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR4-R26): Imported `Metadata` type from `next` and updated the `metadata` export to use `Metadata` type.
* [`src/app/page.tsx`](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR4-R26): Added Open Graph metadata including type, title, description, and image details to improve SEO and social media sharing.
* [`src/app/page.tsx`](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR4-R26): Added Twitter card metadata including card type, title, description, and image details to enhance Twitter sharing.