### PR TITLE
Refine contact infrastructure configuration

### DIFF
--- a/infrastructure/bin/app.ts
+++ b/infrastructure/bin/app.ts
@@ -67,11 +67,16 @@ const monitoringStack = new MonitoringStack(app, getStackName("monitoring", "pro
 monitoringStack.addDependency(storageStack);
 
 // Email Stack
+const emailConfig = CONFIG.prod.email;
+
 const emailStack = new EmailStack(app, getStackName("email", "prod"), {
   env,
   domainName: CONFIG.prod.domainName,
   environment: CONFIG.prod.environment,
   hostedZone: dnsStack.hostedZone,
+  senderEmail: emailConfig.sender,
+  recipientEmail: emailConfig.recipient,
+  allowedOrigins: emailConfig.allowedOrigins,
   tags: CONFIG.tags,
 });
 

--- a/infrastructure/lib/constants.ts
+++ b/infrastructure/lib/constants.ts
@@ -2,10 +2,28 @@ export const CONFIG = {
   dev: {
     domainName: "dev.bjornmelin.io",
     environment: "dev" as const,
+    email: {
+      sender: "no-reply@dev.bjornmelin.io",
+      recipient: "dev-contact@bjornmelin.io",
+      allowedOrigins: [
+        "https://dev.bjornmelin.io",
+        "https://www.dev.bjornmelin.io",
+        "https://api.dev.bjornmelin.io",
+      ],
+    },
   },
   prod: {
     domainName: "bjornmelin.io",
     environment: "prod" as const,
+    email: {
+      sender: "no-reply@bjornmelin.io",
+      recipient: "bjornmelin16@gmail.com",
+      allowedOrigins: [
+        "https://bjornmelin.io",
+        "https://www.bjornmelin.io",
+        "https://api.bjornmelin.io",
+      ],
+    },
   },
   tags: {
     Project: "Portfolio",

--- a/infrastructure/lib/functions/contact-form/index.ts
+++ b/infrastructure/lib/functions/contact-form/index.ts
@@ -15,12 +15,34 @@ const recipientEmail = requireEnv("RECIPIENT_EMAIL");
 
 const ses = new SESClient({ region });
 
-// Allowed origins (replace with your actual domains)
-const allowedOrigins = [
-  process.env.ALLOWED_ORIGIN,
-  process.env.DOMAIN_NAME ? `https://${process.env.DOMAIN_NAME}` : undefined,
-  process.env.DOMAIN_NAME ? `https://www.${process.env.DOMAIN_NAME}` : undefined,
-].filter((origin): origin is string => typeof origin === "string" && origin.length > 0);
+const parseAllowedOrigins = (): string[] => {
+  const origins = new Set<string>();
+  const csvOrigins = process.env.ALLOWED_ORIGINS;
+  if (csvOrigins) {
+    for (const origin of csvOrigins.split(",")) {
+      const trimmed = origin.trim();
+      if (trimmed) {
+        origins.add(trimmed);
+      }
+    }
+  }
+
+  const singleOrigin = process.env.ALLOWED_ORIGIN;
+  if (singleOrigin) {
+    origins.add(singleOrigin);
+  }
+
+  const domainName = process.env.DOMAIN_NAME;
+  if (domainName) {
+    origins.add(`https://${domainName}`);
+    origins.add(`https://www.${domainName}`);
+    origins.add(`https://api.${domainName}`);
+  }
+
+  return Array.from(origins);
+};
+
+const allowedOrigins = parseAllowedOrigins();
 
 // Types
 interface ContactFormData {

--- a/infrastructure/lib/types/stack-props.ts
+++ b/infrastructure/lib/types/stack-props.ts
@@ -26,4 +26,7 @@ export interface MonitoringStackProps extends BaseStackProps {
 
 export interface EmailStackProps extends BaseStackProps {
   hostedZone: route53.IHostedZone;
+  senderEmail: string;
+  recipientEmail: string;
+  allowedOrigins?: string[];
 }

--- a/src/components/contact/contact-form.tsx
+++ b/src/components/contact/contact-form.tsx
@@ -2,7 +2,7 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { AlertCircle, CheckCircle2, Loader2 } from "lucide-react";
-import { useId, useState } from "react";
+import { useId, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -22,9 +22,15 @@ export function ContactForm() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [formStatus, setFormStatus] = useState<"idle" | "success" | "error">("idle");
   const { toast } = useToast();
-  const nameId = useId();
-  const emailId = useId();
-  const messageId = useId();
+  const idPrefix = useId();
+  const fieldIds = useMemo(
+    () => ({
+      name: `${idPrefix}-name`,
+      email: `${idPrefix}-email`,
+      message: `${idPrefix}-message`,
+    }),
+    [idPrefix],
+  );
 
   const {
     register,
@@ -113,57 +119,57 @@ export function ContactForm() {
 
       <form onSubmit={handleSubmit(onSubmit)} className="space-y-6" noValidate>
         <div className="space-y-2">
-          <Label htmlFor={nameId}>Name</Label>
+          <Label htmlFor={fieldIds.name}>Name</Label>
           <Input
-            id={nameId}
+            id={fieldIds.name}
             type="text"
             placeholder="Your name"
             {...register("name")}
-            aria-describedby={errors.name ? `${nameId}-error` : undefined}
+            aria-describedby={errors.name ? `${fieldIds.name}-error` : undefined}
             aria-invalid={!!errors.name}
             disabled={isSubmitting}
             className={errors.name ? "border-red-500" : ""}
           />
           {errors.name && (
-            <p id={`${nameId}-error`} className="text-sm text-red-500">
+            <p id={`${fieldIds.name}-error`} className="text-sm text-red-500">
               {errors.name.message}
             </p>
           )}
         </div>
 
         <div className="space-y-2">
-          <Label htmlFor={emailId}>Email</Label>
+          <Label htmlFor={fieldIds.email}>Email</Label>
           <Input
-            id={emailId}
+            id={fieldIds.email}
             type="email"
             placeholder="your.email@example.com"
             {...register("email")}
-            aria-describedby={errors.email ? `${emailId}-error` : undefined}
+            aria-describedby={errors.email ? `${fieldIds.email}-error` : undefined}
             aria-invalid={!!errors.email}
             disabled={isSubmitting}
             className={errors.email ? "border-red-500" : ""}
           />
           {errors.email && (
-            <p id={`${emailId}-error`} className="text-sm text-red-500">
+            <p id={`${fieldIds.email}-error`} className="text-sm text-red-500">
               {errors.email.message}
             </p>
           )}
         </div>
 
         <div className="space-y-2">
-          <Label htmlFor={messageId}>Message</Label>
+          <Label htmlFor={fieldIds.message}>Message</Label>
           <Textarea
-            id={messageId}
+            id={fieldIds.message}
             placeholder="Your message..."
             {...register("message")}
-            aria-describedby={errors.message ? `${messageId}-error` : undefined}
+            aria-describedby={errors.message ? `${fieldIds.message}-error` : undefined}
             aria-invalid={!!errors.message}
             disabled={isSubmitting}
             rows={5}
             className={errors.message ? "border-red-500" : ""}
           />
           {errors.message && (
-            <p id={`${messageId}-error`} className="text-sm text-red-500">
+            <p id={`${fieldIds.message}-error`} className="text-sm text-red-500">
               {errors.message.message}
             </p>
           )}

--- a/src/components/structured-data.tsx
+++ b/src/components/structured-data.tsx
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 export function generatePersonSchema() {
   return {
     "@context": "https://schema.org",
@@ -57,9 +59,12 @@ interface StructuredDataProps {
 }
 
 const createSchemaKey = (schema: Record<string, unknown>): string => {
-  const type = typeof schema["@type"] === "string" ? (schema["@type"] as string) : "schema";
-  const name = typeof schema.name === "string" ? (schema.name as string) : "default";
-  return `${type}-${name}`;
+  const type = typeof schema["@type"] === "string" ? (schema["@type"] as string) : undefined;
+  const name = typeof schema.name === "string" ? (schema.name as string) : undefined;
+  const baseKey = [type, name].filter(Boolean).join("-");
+  const serialized = JSON.stringify(schema);
+  const digest = createHash("sha256").update(serialized).digest("hex").slice(0, 12);
+  return baseKey ? `${baseKey}-${digest}` : digest;
 };
 
 export default function StructuredData({ type }: StructuredDataProps) {


### PR DESCRIPTION
## Summary
- parameterize the email CDK stack with explicit sender/recipient configuration and normalized allowed origins
- harden the contact form Lambda by parsing configured origin lists and relying on the new environment variables
- stabilize client-side IDs in the contact form and hash JSON-LD schema keys to avoid collisions

## Testing
- pnpm lint
- pnpm test --run

------
https://chatgpt.com/codex/tasks/task_e_68daf74c1768832b81e907c23fd8fa59

## Summary by Sourcery

Refine the contact email infrastructure by parameterizing and validating sender/recipient settings, strengthening CORS origin handling, stabilizing client-side form element IDs, and ensuring unique JSON-LD schema keys

New Features:
- Parameterize the Email CDK stack with explicit sender, recipient, and allowed origins configuration sourced from constants

Enhancements:
- Harden the contact-form Lambda by parsing and normalizing allowed origins from environment variables
- Normalize and deduplicate allowed origins in the CDK stack and apply them to CORS settings

Chores:
- Update React ContactForm to generate stable field IDs via useId and useMemo
- Enhance JSON-LD structured data by hashing schema content for unique keys
- Propagate email configuration in the infrastructure entry point and stack prop types