### PR TITLE
fix(security): require https generated source urls

### DIFF
--- a/src/__tests__/schemas/agent-skills-catalog-schema.test.ts
+++ b/src/__tests__/schemas/agent-skills-catalog-schema.test.ts
@@ -1,0 +1,101 @@
+/* @vitest-environment node */
+import { describe, expect, it } from "vitest";
+import agentSkillsGenerated from "@/content/agent-skills/agent-skills.generated.json";
+import { agentSkillsCatalogSchema } from "@/lib/schemas/agent-skills-catalog";
+
+const generatedCatalogSkill = {
+  name: "deep-researcher",
+  slug: "deep-researcher",
+  description: "Research workflow with evidence-led reporting.",
+  path: "skills/deep-researcher",
+  skillMdPath: "skills/deep-researcher/SKILL.md",
+  sourceUrls: {
+    directory: "https://github.com/BjornMelin/dev-skills/tree/main/skills/deep-researcher",
+    skillMd: "https://github.com/BjornMelin/dev-skills/blob/main/skills/deep-researcher/SKILL.md",
+  },
+  installCommands: {
+    codexGlobal: "codex skills install deep-researcher",
+    codexProject: "codex skills install --project deep-researcher",
+    allAgents: "agents install deep-researcher",
+  },
+  readinessLabels: ["Valid", "Packaged"],
+  qualitySignals: [],
+  improvementSignals: [],
+  resources: {
+    references: 1,
+    scripts: 1,
+    assets: 0,
+    templates: 0,
+    agents: 1,
+    total: 3,
+  },
+  exposure: {
+    readme_catalog: true,
+    docs_index: true,
+  },
+  package: {
+    path: "dist/deep-researcher.skill",
+    present: true,
+    rejected: false,
+  },
+};
+
+function buildGeneratedCatalog(overrides: Record<string, unknown> = {}) {
+  return {
+    schemaVersion: "agent_skills_lab_catalog.v1",
+    generatedAt: "2026-05-25T00:00:00Z",
+    sourceRepository: "https://github.com/BjornMelin/dev-skills",
+    sourceCommit: "abcdef1",
+    skillsCount: 1,
+    totalSkillDirectories: 1,
+    installCommands: {
+      list: "npx skills list",
+      installAllCodex: "npx skills add --all",
+      installAllAgents: "agents install --all",
+    },
+    skills: [generatedCatalogSkill],
+    ...overrides,
+  };
+}
+
+function buildGeneratedCatalogWithSourceUrls(
+  sourceUrls: Partial<typeof generatedCatalogSkill.sourceUrls>,
+) {
+  return buildGeneratedCatalog({
+    skills: [
+      {
+        ...generatedCatalogSkill,
+        sourceUrls: {
+          ...generatedCatalogSkill.sourceUrls,
+          ...sourceUrls,
+        },
+      },
+    ],
+  });
+}
+
+describe("agentSkillsCatalogSchema", () => {
+  it("parses the canonical generated catalog", () => {
+    const parsed = agentSkillsCatalogSchema.parse(agentSkillsGenerated);
+
+    expect(parsed.schemaVersion).toBe("agent_skills_lab_catalog.v1");
+    expect(parsed.skills.length).toBeGreaterThan(0);
+    expect(parsed.sourceRepository).toBe("https://github.com/BjornMelin/dev-skills");
+  });
+
+  it("rejects non-https catalog source URLs", () => {
+    const unsafeSourceRepository = buildGeneratedCatalog({
+      sourceRepository: "http://example.com/dev-skills",
+    });
+    const unsafeDirectory = buildGeneratedCatalogWithSourceUrls({
+      directory: "javascript:alert(1)",
+    });
+    const unsafeSkillMd = buildGeneratedCatalogWithSourceUrls({
+      skillMd: "http://example.com/SKILL.md",
+    });
+
+    expect(agentSkillsCatalogSchema.safeParse(unsafeSourceRepository).success).toBe(false);
+    expect(agentSkillsCatalogSchema.safeParse(unsafeDirectory).success).toBe(false);
+    expect(agentSkillsCatalogSchema.safeParse(unsafeSkillMd).success).toBe(false);
+  });
+});

--- a/src/__tests__/schemas/agent-skills-catalog-schema.test.ts
+++ b/src/__tests__/schemas/agent-skills-catalog-schema.test.ts
@@ -84,6 +84,11 @@ describe("agentSkillsCatalogSchema", () => {
   });
 
   it("rejects non-https catalog source URLs", () => {
+    expect(agentSkillsCatalogSchema.safeParse(buildGeneratedCatalog()).success).toBe(true);
+    expect(
+      agentSkillsCatalogSchema.safeParse(buildGeneratedCatalogWithSourceUrls({})).success,
+    ).toBe(true);
+
     const unsafeSourceRepository = buildGeneratedCatalog({
       sourceRepository: "http://example.com/dev-skills",
     });

--- a/src/__tests__/schemas/github-projects-schema.test.ts
+++ b/src/__tests__/schemas/github-projects-schema.test.ts
@@ -16,7 +16,7 @@ describe("githubProjectsFileSchema", () => {
       expect.objectContaining({
         id: expect.any(String),
         name: expect.any(String),
-        url: expect.stringMatching(/^https?:\/\//),
+        url: expect.stringMatching(/^https:\/\//),
         stars: expect.any(Number),
         forks: expect.any(Number),
         updated: expect.any(String),

--- a/src/__tests__/schemas/github-projects-schema.test.ts
+++ b/src/__tests__/schemas/github-projects-schema.test.ts
@@ -45,6 +45,9 @@ describe("githubProjectsFileSchema", () => {
     });
 
     expect(
+      githubProjectsFileSchema.safeParse(buildGeneratedProjects("https://example.com")).success,
+    ).toBe(true);
+    expect(
       githubProjectsFileSchema.safeParse(buildGeneratedProjects("javascript:alert(1)")).success,
     ).toBe(false);
     expect(

--- a/src/lib/schemas/agent-skills-catalog.ts
+++ b/src/lib/schemas/agent-skills-catalog.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { httpsUrlSchema } from "@/lib/schemas/https-url";
 
 /** Schema for top-level install commands in the Agent Skills Lab catalog. */
 export const agentSkillsCatalogInstallCommandsSchema = z.looseObject({
@@ -9,8 +10,8 @@ export const agentSkillsCatalogInstallCommandsSchema = z.looseObject({
 
 /** Schema for source URLs attached to a catalogued skill. */
 export const agentSkillsCatalogSourceUrlsSchema = z.looseObject({
-  directory: z.url(),
-  skillMd: z.url(),
+  directory: httpsUrlSchema,
+  skillMd: httpsUrlSchema,
 });
 
 /** Schema for install commands attached to a catalogued skill. */
@@ -65,7 +66,7 @@ export const agentSkillsCatalogSkillSchema = z.looseObject({
 export const agentSkillsCatalogSchema = z.looseObject({
   schemaVersion: z.literal("agent_skills_lab_catalog.v1"),
   generatedAt: z.string().datetime({ offset: true }),
-  sourceRepository: z.url(),
+  sourceRepository: httpsUrlSchema,
   sourceCommit: z.string().regex(/^[0-9a-f]{7,40}$/i),
   skillsCount: z.int().nonnegative(),
   totalSkillDirectories: z.int().nonnegative(),

--- a/src/lib/schemas/github-projects.ts
+++ b/src/lib/schemas/github-projects.ts
@@ -1,8 +1,5 @@
 import { z } from "zod";
-
-const httpsUrlSchema = z.url().refine((value) => new URL(value).protocol === "https:", {
-  message: "Expected an https URL.",
-});
+import { httpsUrlSchema } from "@/lib/schemas/https-url";
 
 /** Schema for repository metadata in the generated projects JSON. */
 export const githubProjectsMetadataSchema = z.looseObject({

--- a/src/lib/schemas/https-url.ts
+++ b/src/lib/schemas/https-url.ts
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+/** Schema for public external URLs that must use HTTPS. */
+export const httpsUrlSchema = z.url().refine((value) => new URL(value).protocol === "https:", {
+  message: "Expected an https URL.",
+});


### PR DESCRIPTION
## Summary

- Require HTTPS for generated public source URLs through a shared Zod schema.
- Apply the HTTPS-only contract to Agent Skills Lab catalog source links and source repository metadata.
- Add schema tests that parse the canonical catalog and reject http/javascript source URLs.

## Validation

- pnpm exec biome format --write src/lib/schemas/https-url.ts src/lib/schemas/github-projects.ts src/lib/schemas/agent-skills-catalog.ts src/__tests__/schemas/agent-skills-catalog-schema.test.ts src/__tests__/schemas/github-projects-schema.test.ts
- rtk test pnpm vitest run src/__tests__/schemas/agent-skills-catalog-schema.test.ts src/__tests__/schemas/github-projects-schema.test.ts
- rtk err pnpm lint
- rtk err pnpm type-check
- rtk test pnpm test
- git diff --check
- rg -n --pcre2 "\\x{2014}" . -g '!node_modules/**' -g '!out/**' -g '!.next/**' -g '!opensrc/**' (no matches; exit 1)
- rtk err pnpm build
- rtk err gitleaks protect --staged --redact

## Notes

- `pnpm build` passed but changed tracked CSP hash artifacts nondeterministically on consecutive runs; those generated artifact changes were excluded from this narrow schema PR.
- A full-tree `gitleaks detect --no-git --redact --source .` reported existing repository findings, so this PR uses staged-diff secret scanning as the branch gate.
