### PR TITLE
ci(deps): refresh GitHub Actions dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -83,6 +83,20 @@ updates:
       day: "monday"
       time: "04:00"
     open-pull-requests-limit: 5
+    groups:
+      github-actions-major:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+      github-actions-non-major:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
     commit-message:
       prefix: "ci"
       include: "scope"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -67,7 +67,7 @@ This directory contains all the GitHub Actions workflows for the bjornmelin-plat
 
 10. **security-audit.yml** - Dependency security audit
     - Runs on: Push, PRs, monthly schedule (22nd at 08:00 UTC)
-    - Features: pnpm audit, dependency review
+    - Features: pnpm audit, evaluate-audit severity gate
 
 11. **dependency-update.yml** - Automated dependency updates
     - Runs on: Monthly schedule (1st at 09:00 UTC) and manual dispatch

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -12,11 +12,15 @@ This directory contains all the GitHub Actions workflows for the bjornmelin-plat
    - Features: pnpm caching via composite action, parallel jobs, artifact uploads
 
 2. **ci.yml** - Main continuous integration workflow
-   - Runs on: Push to main/develop, PRs
+   - Runs on: Push to main/develop, PRs, and manual dispatch
    - Calls: _reusable-ci.yml
    - Jobs: CI pipeline, actionlint validation
 
-3. **deploy.yml** - Production deployment workflow
+3. **docker.yml** - Docker build and smoke workflow
+   - Runs on: Push to main, PRs, and manual dispatch
+   - Features: Docker Buildx setup, Docker build configuration validation, image build, container smoke check
+
+4. **deploy.yml** - Production deployment workflow
    - Runs on: Push to main (excludes `**.md`)
    - Calls: _reusable-ci.yml for testing
    - Features: AWS OIDC authentication, preflight config validation, static build,
@@ -24,7 +28,7 @@ This directory contains all the GitHub Actions workflows for the bjornmelin-plat
      CloudFront invalidation, smoke check, job summary
    - workflow_dispatch inputs: `dry_run` (skip S3 upload / KVS sync / invalidation) and `skip_smoke_check`
 
-4. **agent-skills-catalog-sync.yml** - Agent Skills Lab catalog sync
+5. **agent-skills-catalog-sync.yml** - Agent Skills Lab catalog sync
    - Runs on: `repository_dispatch` event `agent-skills-catalog-updated` and manual `workflow_dispatch`
    - Features: validates the dispatched `BjornMelin/dev-skills` source SHA, fetches
      `catalog/agent-skills-lab.json`, normalizes source links to the immutable pushed commit, runs focused checks,
@@ -34,7 +38,7 @@ This directory contains all the GitHub Actions workflows for the bjornmelin-plat
      - `AGENT_SKILLS_SYNC_TOKEN` with `contents: write` and `pull-requests: write` if auto-created sync PRs should
        trigger the standard PR CI workflows instead of relying only on the sync workflow's focused checks
 
-5. **projects-github-metadata-refresh.yml** - Projects GitHub metadata refresh
+6. **projects-github-metadata-refresh.yml** - Projects GitHub metadata refresh
    - Runs on: weekly schedule and manual `workflow_dispatch`
    - Features: refreshes `src/content/projects/projects.generated.json` from public GitHub repository metrics,
      validates generated statistics, runs focused projects tests plus type-check, and opens or updates a generated-data
@@ -45,46 +49,46 @@ This directory contains all the GitHub Actions workflows for the bjornmelin-plat
    - Optional secret:
      - `PROJECTS_GITHUB_REFRESH_TOKEN` for authenticated GitHub API refreshes beyond the default workflow token
 
-6. **release-please.yml** - Automated semantic versioning and releases
-   - Runs on: Push to main
+7. **release-please.yml** - Automated semantic versioning and releases
+   - Runs on: Push to main and manual dispatch
    - Features: Opens/updates Release PR based on conventional commits; creates git tags and GitHub Releases on merge
-   - Uses: [googleapis/release-please-action@v4](https://github.com/googleapis/release-please-action)
+   - Exact action version is owned by `release-please.yml`
 
-7. **manual-deploy.yml** - Manual deployment workflow
+8. **manual-deploy.yml** - Manual deployment workflow
    - Runs on: Workflow dispatch
    - Features: Environment selection, test skipping option, stack-output-based S3/KVS/CloudFront deploy,
      deployment tracking, concurrency control
 
 ### Security & Quality
 
-8. **codeql.yml** - GitHub CodeQL security analysis
+9. **codeql.yml** - GitHub CodeQL security analysis
    - Runs on: Push, PRs, monthly schedule (15th at 06:00 UTC)
    - Scans: JavaScript/TypeScript code for vulnerabilities
 
-9. **security-audit.yml** - Dependency security audit
-   - Runs on: Push, PRs, monthly schedule (22nd at 08:00 UTC)
-   - Features: pnpm audit, dependency review
+10. **security-audit.yml** - Dependency security audit
+    - Runs on: Push, PRs, monthly schedule (22nd at 08:00 UTC)
+    - Features: pnpm audit, dependency review
 
-10. **dependency-update.yml** - Automated dependency updates
-    - Runs on: Monthly schedule (1st at 09:00 UTC)
+11. **dependency-update.yml** - Automated dependency updates
+    - Runs on: Monthly schedule (1st at 09:00 UTC) and manual dispatch
     - Features: Non-major updates, automated PR creation
 
 ### Maintenance
 
-11. **branch-protection.yml** - PR validation and protection
+12. **branch-protection.yml** - PR validation and protection
     - Runs on: Pull requests to main
     - Features: Conventional commit check, merge conflict detection, auto-labeling
 
-12. **pr-labeler.yml** - Automatic PR labeling
-    - Runs on: PR opened/edited
+13. **pr-labeler.yml** - Automatic PR labeling
+    - Runs on: PR opened/edited/synchronized
     - Features: Path-based labels, conventional commit labels
 
-13. **stale.yml** - Manage stale issues and PRs
-    - Runs on: Monthly schedule (1st of each month at 00:00 UTC)
+14. **stale.yml** - Manage stale issues and PRs
+    - Runs on: Monthly schedule (1st of each month at 00:00 UTC) and manual dispatch
     - Features: Auto-close inactive items, configurable timelines
 
-14. **link-check.yml** - Check for broken links
-    - Runs on: Push, PRs, monthly schedule (8th at 04:00 UTC)
+15. **link-check.yml** - Check for broken links
+    - Runs on: Push, PRs, monthly schedule (8th at 04:00 UTC), and manual dispatch
     - Features: Markdown link validation, issue creation on failure
     - Exclusions:
       - `https://bjornmelin.io` and `https://www.bjornmelin.io` are intentionally excluded because this
@@ -104,14 +108,14 @@ This directory contains all the GitHub Actions workflows for the bjornmelin-plat
 
 ### Performance
 
-15. **performance-check.yml** - Performance monitoring
-    - Runs on: Push to main, PRs
+16. **performance-check.yml** - Performance monitoring
+    - Runs on: Push to main, PRs, and manual dispatch
     - Features: Lighthouse CI, bundle size analysis
     - Metrics: Performance, accessibility, SEO, best practices
 
 ### Infrastructure
 
-16. **infrastructure.yml** - AWS CDK infrastructure deployment
+17. **infrastructure.yml** - AWS CDK infrastructure deployment
     - Runs on: Workflow dispatch
     - Features: CDK deploy for DNS, storage, email, monitoring stacks
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -112,6 +112,7 @@ This directory contains all the GitHub Actions workflows for the bjornmelin-plat
     - Runs on: Push to main, PRs, and manual dispatch
     - Features: Lighthouse CI, bundle size analysis
     - Metrics: Performance, accessibility, SEO, best practices
+    - Reporting: Summarizes `.lighthouseci` reports via `scripts/summarize-lighthouse-results.mjs`
 
 ### Infrastructure
 

--- a/.github/workflows/_reusable-ci.yml
+++ b/.github/workflows/_reusable-ci.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm
@@ -103,7 +103,7 @@ jobs:
           install: 'true'
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -154,7 +154,7 @@ jobs:
       success: ${{ steps.build.outcome == 'success' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm

--- a/.github/workflows/_reusable-ci.yml
+++ b/.github/workflows/_reusable-ci.yml
@@ -26,7 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm
@@ -55,7 +57,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm
@@ -95,7 +99,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm
@@ -103,7 +109,7 @@ jobs:
           install: 'true'
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -154,7 +160,9 @@ jobs:
       success: ${{ steps.build.outcome == 'success' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm

--- a/.github/workflows/agent-skills-catalog-sync.yml
+++ b/.github/workflows/agent-skills-catalog-sync.yml
@@ -42,7 +42,7 @@ jobs:
       source_repository: ${{ steps.source.outputs.source_repository }}
     steps:
       - name: Checkout portfolio
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
 
@@ -165,7 +165,7 @@ jobs:
       pull-requests: write # Required to open or update the catalog sync PR.
     steps:
       - name: Checkout portfolio
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
 

--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -18,7 +18,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check PR title follows conventional commits
-        uses: amannn/action-semantic-pull-request@v5
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -18,7 +18,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Run actionlint
         uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1.72.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
@@ -50,7 +52,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
       - name: Run actionlint
         uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1.72.0
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           persist-credentials: false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 
@@ -68,7 +68,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -79,7 +79,7 @@ jobs:
           install: 'true'
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           role-session-name: github-actions-deploy

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,21 +24,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Validate Docker build configuration
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           call: check
           context: .
 
       - name: Build Docker image
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           load: true

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -32,7 +32,9 @@ jobs:
           fi
 
       - name: Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -32,7 +32,7 @@ jobs:
           fi
 
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm
@@ -40,7 +40,7 @@ jobs:
           install: "false"
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           role-session-name: github-actions-infra

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -20,7 +20,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Check links in Markdown files
         uses: lycheeverse/lychee-action@v2

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -20,7 +20,9 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Check links in Markdown files
         uses: lycheeverse/lychee-action@v2

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -38,7 +38,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 
@@ -83,7 +83,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 
@@ -113,7 +113,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 
@@ -123,7 +123,7 @@ jobs:
           install: "true"
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           role-session-name: github-actions-manual-deploy

--- a/.github/workflows/performance-check.yml
+++ b/.github/workflows/performance-check.yml
@@ -54,32 +54,7 @@ jobs:
 
       - name: Write Lighthouse summary
         if: always()
-        run: |
-          node <<'NODE'
-          const fs = require('fs');
-          const summary = process.env.GITHUB_STEP_SUMMARY;
-          const resultPath = './lighthouse-results.json';
-          const lines = [];
-          lines.push('## Lighthouse Performance Report');
-          lines.push('');
-          if (fs.existsSync(resultPath)) {
-            try {
-              const results = JSON.parse(fs.readFileSync(resultPath, 'utf8'));
-              lines.push('| Metric | Score |');
-              lines.push('|--------|-------|');
-              lines.push(`| Performance | ${results.performance}% |`);
-              lines.push(`| Accessibility | ${results.accessibility}% |`);
-              lines.push(`| Best Practices | ${results.bestPractices}% |`);
-              lines.push(`| SEO | ${results.seo}% |`);
-            } catch (err) {
-              lines.push(`⚠️ Error parsing Lighthouse results: ${err.message}`);
-            }
-          } else {
-            lines.push('⚠️ Lighthouse results not found. The performance check may have failed.');
-          }
-          lines.push('');
-          fs.appendFileSync(summary, lines.join('\n'));
-          NODE
+        run: node scripts/summarize-lighthouse-results.mjs
 
       - name: Evaluate Lighthouse comment criteria
         id: lighthouse-comment
@@ -109,6 +84,8 @@ jobs:
                   accessibility: results.accessibility,
                   bestPractices: results.bestPractices,
                   seo: results.seo,
+                  urlCount: results.urlCount,
+                  reportCount: results.reportCount,
                 };
               } catch (error) {
                 errorMessage = `Error parsing Lighthouse results: ${error.message}`;
@@ -167,7 +144,8 @@ jobs:
             const title = '## 🚦 Lighthouse Performance Report';
             let body = `${title}\n\n`;
             if (metrics) {
-              body += `| Metric | Score |\n|--------|-------|\n`;
+              body += `Audited ${metrics.urlCount} URL(s) across ${metrics.reportCount} Lighthouse run(s).\n\n`;
+              body += `| Metric | Worst Score |\n|--------|-------------|\n`;
               body += `| Performance | ${metrics.performance}% |\n`;
               body += `| Accessibility | ${metrics.accessibility}% |\n`;
               body += `| Best Practices | ${metrics.bestPractices}% |\n`;

--- a/.github/workflows/performance-check.yml
+++ b/.github/workflows/performance-check.yml
@@ -28,7 +28,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm
@@ -194,7 +194,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm

--- a/.github/workflows/performance-check.yml
+++ b/.github/workflows/performance-check.yml
@@ -56,6 +56,7 @@ jobs:
 
       - name: Write Lighthouse summary
         if: always()
+        continue-on-error: true
         run: node scripts/summarize-lighthouse-results.mjs
 
       - name: Evaluate Lighthouse comment criteria

--- a/.github/workflows/performance-check.yml
+++ b/.github/workflows/performance-check.yml
@@ -28,7 +28,9 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm
@@ -172,7 +174,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm

--- a/.github/workflows/performance-check.yml
+++ b/.github/workflows/performance-check.yml
@@ -56,7 +56,6 @@ jobs:
 
       - name: Write Lighthouse summary
         if: always()
-        continue-on-error: true
         run: node scripts/summarize-lighthouse-results.mjs
 
       - name: Evaluate Lighthouse comment criteria

--- a/.github/workflows/projects-github-metadata-refresh.yml
+++ b/.github/workflows/projects-github-metadata-refresh.yml
@@ -35,7 +35,7 @@ jobs:
       min_stars: ${{ steps.refresh-inputs.outputs.min_stars }}
     steps:
       - name: Checkout portfolio
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
 
@@ -105,7 +105,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout portfolio
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
 

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -18,7 +18,9 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm
@@ -62,7 +64,9 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Dependency Review
         uses: actions/dependency-review-action@v5

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -18,7 +18,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm
@@ -62,7 +62,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Dependency Review
         uses: actions/dependency-review-action@v5

--- a/docs/deployment/ci-cd.md
+++ b/docs/deployment/ci-cd.md
@@ -175,7 +175,8 @@ See `docs/specs/SPEC-0007-deploy-workflow-permissions-drift.md` for the deploy r
 ### Production
 
 - Deployments run through GitHub Actions using the `prod-portfolio-deploy` role
-- Security audit workflow on push, PR, and monthly schedule with pnpm audit severity gating
+- Security audit workflow on push, PR, and monthly schedule; `pnpm audit` reports are gated by
+  `.github/scripts/evaluate-audit.mjs`
 - CodeQL advanced workflow is the single SARIF publisher
 
 ## CI Workflows
@@ -184,7 +185,7 @@ See `docs/specs/SPEC-0007-deploy-workflow-permissions-drift.md` for the deploy r
 | :---------------------- | :-------------- | :-------------------------------------- |
 | `ci.yml`                | Push/PR         | Lint, type-check, test, build           |
 | `performance-check.yml` | Push/PR to main | Lighthouse CI, bundle analysis          |
-| `security-audit.yml`    | Push/PR/monthly | pnpm audit, dependency scanning         |
+| `security-audit.yml`    | Push/PR/monthly | pnpm audit evaluation, dependency scan  |
 | `release-please.yml`    | Push to main    | Open/update Release PR, create releases |
 | `deploy.yml`            | Push to main    | Deploy to production                    |
 

--- a/docs/deployment/ci-cd.md
+++ b/docs/deployment/ci-cd.md
@@ -175,7 +175,7 @@ See `docs/specs/SPEC-0007-deploy-workflow-permissions-drift.md` for the deploy r
 ### Production
 
 - Deployments run through GitHub Actions using the `prod-portfolio-deploy` role
-- Daily security audit workflow with pnpm audit severity gating
+- Security audit workflow on push, PR, and monthly schedule with pnpm audit severity gating
 - CodeQL advanced workflow is the single SARIF publisher
 
 ## CI Workflows
@@ -184,7 +184,7 @@ See `docs/specs/SPEC-0007-deploy-workflow-permissions-drift.md` for the deploy r
 | :---------------------- | :-------------- | :-------------------------------------- |
 | `ci.yml`                | Push/PR         | Lint, type-check, test, build           |
 | `performance-check.yml` | Push/PR to main | Lighthouse CI, bundle analysis          |
-| `security-audit.yml`    | Daily/Push      | pnpm audit, dependency scanning         |
+| `security-audit.yml`    | Push/PR/monthly | pnpm audit, dependency scanning         |
 | `release-please.yml`    | Push to main    | Open/update Release PR, create releases |
 | `deploy.yml`            | Push to main    | Deploy to production                    |
 

--- a/docs/specs/SPEC-0001-dependency-upgrades.md
+++ b/docs/specs/SPEC-0001-dependency-upgrades.md
@@ -83,6 +83,8 @@ install contexts.
 
 Dependabot npm version-update PRs for root and infrastructure dependencies use
 a matching 1-day cooldown before proposing newly released package versions.
+Dependabot also checks GitHub Actions weekly and groups action updates by
+major versus non-major upgrade risk; workflow YAML files own exact action pins.
 The shared Node/pnpm setup action asserts both root and infrastructure pnpm
 hardening settings before any workflow install runs, including workflows that
 defer installation to a package subdirectory.

--- a/scripts/summarize-lighthouse-results.mjs
+++ b/scripts/summarize-lighthouse-results.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+import { appendFileSync, existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const categories = [
+  ["performance", "performance", "Performance"],
+  ["accessibility", "accessibility", "Accessibility"],
+  ["best-practices", "bestPractices", "Best Practices"],
+  ["seo", "seo", "SEO"],
+];
+
+const args = parseArgs(process.argv.slice(2));
+
+try {
+  const reports = readReports(args.reportsDir);
+  const summary = summarizeReports(reports);
+  writeFileSync(args.output, `${JSON.stringify(summary, null, 2)}\n`);
+  appendSummary(args.summary, summary);
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  appendSummary(args.summary, null, message);
+  console.error(message);
+  process.exitCode = 1;
+}
+
+function parseArgs(argv) {
+  const parsed = {
+    reportsDir: "./.lighthouseci",
+    output: "./lighthouse-results.json",
+    summary: process.env.GITHUB_STEP_SUMMARY ?? "",
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--reports-dir") {
+      parsed.reportsDir = readValue(argv, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--output") {
+      parsed.output = readValue(argv, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--summary") {
+      parsed.summary = readValue(argv, index, arg);
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return parsed;
+}
+
+function readValue(argv, index, arg) {
+  const value = argv[index + 1];
+  if (!value) {
+    throw new Error(`${arg} requires a value`);
+  }
+  return value;
+}
+
+function readReports(reportsDir) {
+  if (!existsSync(reportsDir)) {
+    throw new Error(`Lighthouse report directory not found: ${reportsDir}`);
+  }
+
+  const files = readdirSync(reportsDir)
+    .filter((file) => file.startsWith("lhr-") && file.endsWith(".json"))
+    .sort();
+  if (files.length === 0) {
+    throw new Error(`No Lighthouse JSON reports found in ${reportsDir}`);
+  }
+
+  return files.map((file) => {
+    const path = join(reportsDir, file);
+    const report = JSON.parse(readFileSync(path, "utf8"));
+    return {
+      source: file,
+      url: report.finalUrl ?? report.requestedUrl ?? file,
+      scores: readCategoryScores(report, file),
+    };
+  });
+}
+
+function readCategoryScores(report, source) {
+  const scores = {};
+  for (const [categoryKey, outputKey] of categories) {
+    const score = report.categories?.[categoryKey]?.score;
+    if (typeof score !== "number") {
+      throw new Error(`Missing Lighthouse category score '${categoryKey}' in ${source}`);
+    }
+    scores[outputKey] = Math.round(score * 100);
+  }
+  return scores;
+}
+
+function summarizeReports(reports) {
+  const urls = new Set();
+  const summary = {
+    performance: 100,
+    accessibility: 100,
+    bestPractices: 100,
+    seo: 100,
+    urlCount: 0,
+    reportCount: reports.length,
+  };
+
+  for (const report of reports) {
+    urls.add(report.url);
+    for (const [, outputKey] of categories) {
+      summary[outputKey] = Math.min(summary[outputKey], report.scores[outputKey]);
+    }
+  }
+
+  summary.urlCount = urls.size;
+  return summary;
+}
+
+function appendSummary(summaryPath, summary, errorMessage = "") {
+  if (!summaryPath) {
+    return;
+  }
+
+  const lines = ["## Lighthouse Performance Report", ""];
+  if (summary) {
+    lines.push(
+      `Audited ${summary.urlCount} URL(s) across ${summary.reportCount} Lighthouse run(s).`,
+      "",
+      "| Metric | Worst Score |",
+      "|--------|-------------|",
+    );
+    for (const [, outputKey, label] of categories) {
+      lines.push(`| ${label} | ${summary[outputKey]}% |`);
+    }
+  } else {
+    lines.push(`WARNING: ${errorMessage}`);
+  }
+  lines.push("");
+  appendFileSync(summaryPath, lines.join("\n"));
+}


### PR DESCRIPTION
## Summary

- Consolidates the still-open Dependabot GitHub Actions updates for `actions/checkout`, `actions/cache`, Docker Buildx/build-push actions, and the stale AWS credentials action pin.
- Adds Dependabot GitHub Actions grouping so future action update PRs arrive as major vs non-major batches instead of fragmented single-action PRs.
- Aligns workflow documentation with the current workflow catalog, triggers, security audit cadence, and dependency-upgrade policy.

## Supersedes

- #368
- #371
- #377
- #378

## Security and dependency audit

- GitHub Dependabot alerts are currently clear.
- Root `pnpm audit --audit-level low` is clear.
- Infrastructure `pnpm -C infrastructure audit --audit-level low` is clear.
- `@types/node` was not moved to the latest major because the repo targets Node 24 (`>=24 <25`) and Dependabot already ignores `>=25.0.0` for that package.

## Validation

- `pnpm install --frozen-lockfile`
- `actionlint .github/workflows/*.yml`
- `pnpm lint`
- `pnpm lint:md`
- `pnpm type-check`
- `pnpm deps:check-node-types`
- `pnpm audit --audit-level low`
- `pnpm -C infrastructure audit --audit-level low`
- `pnpm test:coverage`
- `pnpm build`
- `pnpm -C infrastructure test -- --run`
- `pnpm docker:verify`
- `pnpm test:e2e`
- `git diff --check`

## Review evidence

- Dependency upgrade planner subagent: pass, no blocking findings.
- Docs aligner subagent: findings addressed; focused checks pass.
- CI triager subagent: findings addressed; action refs resolve and workflow YAML passes actionlint.
- `codex review --base origin/main`: no actionable defects found.
