### PR TITLE
docs(ci-cd): diagram the Agent Skills Lab catalog sync + cross-link source

### DIFF
--- a/docs/deployment/ci-cd.md
+++ b/docs/deployment/ci-cd.md
@@ -86,8 +86,9 @@ graph TB
 
 The sync normally fires **instantly** on a `repository_dispatch` from dev-skills (authenticated
 there by the `PLATFORM_REPOSITORY_DISPATCH_TOKEN` secret). It can also be run on demand via
-`workflow_dispatch` — inputs `source_ref` (branch/tag/commit, default `main`) and `source_sha`
-(exact commit, overrides `source_ref`) — which is the fallback if a dispatch is ever missed:
+`workflow_dispatch`, whose inputs are `source_ref` (branch/tag/commit, default `main`) and
+`source_sha` (exact commit, overrides `source_ref`). This is the fallback if a dispatch is ever
+missed:
 
 ```bash
 gh workflow run agent-skills-catalog-sync.yml -R BjornMelin/bjornmelin-platform-io \

--- a/docs/deployment/ci-cd.md
+++ b/docs/deployment/ci-cd.md
@@ -54,12 +54,49 @@ workflow performs the safe sequence to keep the static export and CSP hashes in 
 2. `pnpm -C infrastructure cdk deploy prod-portfolio-storage` (deploys CloudFront Functions + CSP hashes KVS)
 3. `pnpm deploy:static:prod` (S3 upload + CSP hashes KVS sync + CloudFront invalidation)
 
+### Agent Skills Lab catalog sync
+
 The Agent Skills Lab catalog uses a reviewable sync path before production deploys. When
 `BjornMelin/dev-skills` emits the `agent-skills-catalog-updated` repository dispatch event,
 `.github/workflows/agent-skills-catalog-sync.yml` fetches the pushed catalog, validates it,
 updates `src/content/agent-skills/agent-skills.generated.json`, runs focused checks, and opens
 or updates a conventional catalog-sync PR. Merging that PR to `main` uses the normal deploy
 workflow above.
+
+```mermaid
+graph TB
+    subgraph "BjornMelin/dev-skills"
+        DISPATCH["repository_dispatch<br/>agent-skills-catalog-updated"]
+    end
+    subgraph "agent-skills-catalog-sync.yml"
+        FETCH["Fetch + validate catalog at source_sha"]
+        CHECK["Run vitest + type-check"]
+        PR["Open/update PR<br/>chore/agent-skills-catalog-sync"]
+        FETCH --> CHECK --> PR
+    end
+    subgraph "Production"
+        MERGE["Merge PR to main"]
+        DEPLOY["Deploy Portfolio (deploy.yml)"]
+        LIVE["bjornmelin.io/agent-skills"]
+        MERGE --> DEPLOY --> LIVE
+    end
+    DISPATCH --> FETCH
+    PR -->|you merge| MERGE
+```
+
+The sync normally fires **instantly** on a `repository_dispatch` from dev-skills (authenticated
+there by the `PLATFORM_REPOSITORY_DISPATCH_TOKEN` secret). It can also be run on demand via
+`workflow_dispatch` — inputs `source_ref` (branch/tag/commit, default `main`) and `source_sha`
+(exact commit, overrides `source_ref`) — which is the fallback if a dispatch is ever missed:
+
+```bash
+gh workflow run agent-skills-catalog-sync.yml -R BjornMelin/bjornmelin-platform-io \
+  -f source_sha=<dev-skills main commit sha>
+```
+
+The full end-to-end flow, the producer-side verify gate, and the dispatch-token setup are
+documented in dev-skills:
+[`docs/reference/agent-skills-catalog-pipeline.md`](https://github.com/BjornMelin/dev-skills/blob/main/docs/reference/agent-skills-catalog-pipeline.md).
 
 ### Production Build
 


### PR DESCRIPTION
## What

Fleshes out the consumer-side documentation of the **Agent Skills Lab catalog sync** in `docs/deployment/ci-cd.md`, complementing the new authoritative pipeline doc in [`BjornMelin/dev-skills`](https://github.com/BjornMelin/dev-skills/blob/main/docs/reference/agent-skills-catalog-pipeline.md) ([dev-skills#137](https://github.com/BjornMelin/dev-skills/pull/137), merged).

## Changes

- Promote the catalog-sync paragraph to its own `### Agent Skills Lab catalog sync` subsection.
- Add a **Mermaid diagram** (matching the repo's `graph TB` style) of the receive → validate → PR → merge → deploy path.
- Document the **instant `repository_dispatch` trigger** (authenticated on dev-skills by `PLATFORM_REPOSITORY_DISPATCH_TOKEN`) vs. the **manual `workflow_dispatch` fallback** (`source_ref`/`source_sha`), with a copy-paste command.
- **Cross-link** the authoritative end-to-end pipeline doc in dev-skills, so producer-side detail lives in one place rather than being duplicated.

## Verification

- Docs-only change; Mermaid fences balanced, no HTML entities.
- The cross-linked dev-skills doc is already on `main` (returns 200), so the lychee link-check resolves it.