### PR TITLE
feat(agent-skills): gate catalog sync on content change, not commit churn

### DIFF
--- a/.github/workflows/agent-skills-catalog-sync.yml
+++ b/.github/workflows/agent-skills-catalog-sync.yml
@@ -19,6 +19,11 @@ on:
         required: false
         type: string
         default: catalog/agent-skills-lab.json
+      force:
+        description: "Open a sync PR even if only provenance (commit SHA/timestamp) changed"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read # Required for checkout and source catalog fetch.
@@ -40,6 +45,7 @@ jobs:
       catalog_path: ${{ steps.source.outputs.catalog_path }}
       source_ref: ${{ steps.source.outputs.source_ref }}
       source_repository: ${{ steps.source.outputs.source_repository }}
+      changed: ${{ steps.diff.outputs.changed }}
     steps:
       - name: Checkout portfolio
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
@@ -140,6 +146,46 @@ jobs:
 
           cp "${normalized_catalog}" "${TARGET_CATALOG_PATH}"
 
+      - name: Detect catalog content change
+        id: diff
+        env:
+          FORCE: ${{ inputs.force }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # A deliberate provenance refresh, or the very first sync, always proceeds.
+          if [[ "${FORCE}" == "true" ]]; then
+            echo "changed=true" >>"${GITHUB_OUTPUT}"
+            echo "force=true requested: opening a sync PR regardless of the content diff."
+            exit 0
+          fi
+          if ! git cat-file -e "HEAD:${TARGET_CATALOG_PATH}" 2>/dev/null; then
+            echo "changed=true" >>"${GITHUB_OUTPUT}"
+            echo "No committed catalog yet: opening the initial sync PR."
+            exit 0
+          fi
+
+          # Compare MEANINGFUL content only. The catalog embeds the dev-skills commit
+          # SHA in sourceCommit/sourceRef and in every sourceUrl, plus a generatedAt
+          # timestamp, so a raw diff flags every upstream commit even when no skill
+          # changed. Normalize both sides by dropping generatedAt and replacing each
+          # file's own commit SHA with a constant, then diff. A match means only
+          # provenance churned, so there is nothing to sync.
+          committed="$(mktemp)"
+          norm() {
+            jq -S --arg sha "$(jq -r '.sourceCommit' "$1")" \
+              '.generatedAt = "" | walk(if type == "string" then gsub($sha; "<sha>") else . end)' "$1"
+          }
+          git show "HEAD:${TARGET_CATALOG_PATH}" >"${committed}"
+          if diff -q <(norm "${committed}") <(norm "${TARGET_CATALOG_PATH}") >/dev/null; then
+            echo "changed=false" >>"${GITHUB_OUTPUT}"
+            echo "Catalog content unchanged (only provenance SHA/timestamp differ); skipping sync PR."
+          else
+            echo "changed=true" >>"${GITHUB_OUTPUT}"
+            echo "Catalog content changed; a sync PR will be opened or updated."
+          fi
+
       - name: Run catalog checks
         env:
           SKIP_ENV_VALIDATION: 'true'
@@ -159,6 +205,7 @@ jobs:
   create-sync-pr:
     name: Create sync pull request
     needs: sync-catalog
+    if: needs.sync-catalog.outputs.changed == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write # Required to push the generated catalog branch.

--- a/.github/workflows/agent-skills-catalog-sync.yml
+++ b/.github/workflows/agent-skills-catalog-sync.yml
@@ -36,11 +36,15 @@ env:
   EXPECTED_SOURCE_REPOSITORY: BjornMelin/dev-skills
   EXPECTED_CATALOG_PATH: catalog/agent-skills-lab.json
   TARGET_CATALOG_PATH: src/content/agent-skills/agent-skills.generated.json
+  SYNC_PR_BRANCH: chore/agent-skills-catalog-sync
 
 jobs:
   sync-catalog:
     name: Sync generated catalog
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Checkout + git show of the committed catalog.
+      pull-requests: read # Detect an already-open sync PR to reconcile.
     outputs:
       catalog_path: ${{ steps.source.outputs.catalog_path }}
       source_ref: ${{ steps.source.outputs.source_ref }}
@@ -150,6 +154,7 @@ jobs:
         id: diff
         env:
           FORCE: ${{ inputs.force }}
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
@@ -178,12 +183,23 @@ jobs:
               '.generatedAt = "" | walk(if type == "string" then gsub($sha; "<sha>") else . end)' "$1"
           }
           git show "HEAD:${TARGET_CATALOG_PATH}" >"${committed}"
-          if diff -q <(norm "${committed}") <(norm "${TARGET_CATALOG_PATH}") >/dev/null; then
-            echo "changed=false" >>"${GITHUB_OUTPUT}"
-            echo "Catalog content unchanged (only provenance SHA/timestamp differ); skipping sync PR."
-          else
+          if ! diff -q <(norm "${committed}") <(norm "${TARGET_CATALOG_PATH}") >/dev/null; then
             echo "changed=true" >>"${GITHUB_OUTPUT}"
             echo "Catalog content changed; a sync PR will be opened or updated."
+            exit 0
+          fi
+
+          # Content matches main. Still proceed if a sync PR is already open, so
+          # create-pull-request can reconcile it: update it to the latest content,
+          # or close it and delete its branch now that main and upstream agree.
+          # Skipping here would strand a stale PR proposing removed content.
+          open_pr="$(gh pr list --repo "${GITHUB_REPOSITORY}" --head "${SYNC_PR_BRANCH}" --state open --json number --jq 'length')"
+          if [[ "${open_pr}" -gt 0 ]]; then
+            echo "changed=true" >>"${GITHUB_OUTPUT}"
+            echo "Content matches main, but an open ${SYNC_PR_BRANCH} PR exists; proceeding so it is reconciled."
+          else
+            echo "changed=false" >>"${GITHUB_OUTPUT}"
+            echo "Catalog content unchanged (only provenance SHA/timestamp differ) and no open sync PR; skipping."
           fi
 
       - name: Run catalog checks
@@ -242,5 +258,5 @@ jobs:
             - Validation: `pnpm vitest run src/__tests__/data/agent-skills-data.test.ts` and `pnpm type-check`
 
             This PR updates only the generated catalog consumed by `/agent-skills`.
-          branch: chore/agent-skills-catalog-sync
+          branch: ${{ env.SYNC_PR_BRANCH }}
           delete-branch: true


### PR DESCRIPTION
## Problem

The Agent Skills Lab catalog embeds the dev-skills commit SHA (`sourceCommit`, `sourceRef`, and every `sourceUrl`) plus a `generatedAt` timestamp. So the sync compared the fetched catalog against the committed `generated.json` with a raw diff, which flags **every** upstream commit on a dispatch trigger path — including docs-only commits that change no skill content — and opened a provenance-only sync PR (and a deploy) each time.

Observed: merging a docs-only dev-skills PR auto-opened a sync PR whose only change was `sourceCommit`/`sourceRef` + the SHA inside 132 source URLs. 66 skills, identical.

## Fix — a content-change gate (consumer side)

Normalize away the churn before deciding to sync: drop `generatedAt` and replace each file's own commit SHA with a constant, then diff. The `create-sync-pr` job runs **only** when the normalized content actually differs (`needs.sync-catalog.outputs.changed == 'true'`).

## Why this over the alternatives

- **Not narrowing dispatch triggers** — the catalog encodes docs/README readiness signals and is produced by `crates/codex-dev-core`, so trigger paths are legitimate. Narrowing them would silently *miss real changes*. The gate checks content on every trigger and acts only when it changed.
- **Not stripping the SHA from the catalog** — pinned-commit source permalinks (a `main` blob URL 404s on rename) and provenance are worth keeping. The gate preserves them in the committed artifact, accurate as of the last content change.

Also adds a `force` `workflow_dispatch` input to refresh provenance on demand.

## Verification

- `actionlint` clean; YAML parses; repo em-dash rule satisfied.
- Gate logic run against the **live** catalog with the workflow's exact `norm()`:
  - SHA + timestamp churn only → `changed=false` → **skip** ✓
  - resource-count / description change → `changed=true` → **sync** ✓
- Behavior unchanged for real updates and the initial sync (`force`, and a missing committed file, both proceed).